### PR TITLE
Embed digital twin Space on home page

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -20,6 +20,23 @@ These days I work at the intersection of AI engineering and data science, buildi
 
 ---
 
+<section id="digital-twin">
+  <h2>Try the digital twin</h2>
+  <p>A representative agent that answers questions about my work, skills, and projects. The conversation is logged so I can improve it; data stays in a private dataset.</p>
+
+  <iframe
+    src="https://alejandrofupi-digital-twin.hf.space"
+    title="Digital twin chat"
+    style="width: 100%; height: 640px; border: 1px solid #e5e5e5; border-radius: 6px;"
+    loading="lazy"
+    allow="clipboard-write"
+  ></iframe>
+
+  <p><small>Doesn't load? <a href="https://huggingface.co/spaces/Alejandrofupi/digital-twin">Open the chat in a new tab</a>.</small></p>
+</section>
+
+---
+
 ## What I build
 
 End-to-end AI and data systems that prioritise reliability and usability:


### PR DESCRIPTION
## Summary
- Adds an iframe to `_pages/about.md` that embeds the deployed digital twin Space (`https://alejandrofupi-digital-twin.hf.space`) directly between the intro and the "What I build" section, so the chat is the headline interaction rather than a side trip.
- Includes a plain-text fallback link to the Hugging Face Space for clients that block third-party frames.
- Closes Phase 7 / Slice 2 (issue [AlejandroFuentePinero/digital-twin#52](https://github.com/AlejandroFuentePinero/digital-twin/issues/52)).

## Test plan
- [ ] After merge, GitHub Pages deploys cleanly (no Jekyll build error in Actions).
- [ ] Step 12 of the parent-PRD smoke test on desktop: open `alejandrofuentepinero.github.io` cold, scroll to the embed, send 1–2 chat turns, submit the contact form inside the iframe, and verify records land in `Alejandrofupi/digital-twin-logs`.
- [ ] Step 12 on mobile: layout doesn't break; chat is interactive; contact form is reachable.
- [ ] Browser console clean — no `Content-Security-Policy: frame-ancestors` errors.
- [ ] Sentinel sees the embedded turns.

## Rollback
If smoke fails, revert this PR. The Space stays live as a link-out (the fallback `<a>` already labels it as such).

## Notes
- Local Jekyll build was skipped: system Ruby 2.6 in this dev env is below the `ffi` gem's minimum (≥ 3.0) and no Ruby version manager is installed. The change is plain HTML with no Liquid templating, so GH Pages will surface any build error on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)