### PR TITLE
Bump digital-twin iframe height to 900px

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -27,7 +27,7 @@ These days I work at the intersection of AI engineering and data science, buildi
   <iframe
     src="https://alejandrofupi-digital-twin.hf.space"
     title="Digital twin chat"
-    style="width: 100%; height: 640px; border: 1px solid #e5e5e5; border-radius: 6px;"
+    style="width: 100%; height: 900px; border: 1px solid #e5e5e5; border-radius: 6px;"
     loading="lazy"
     allow="clipboard-write"
   ></iframe>


### PR DESCRIPTION
## Summary
- Mid-smoke-test fix: at 640px, the chat composer + send button sat below the visible iframe area, forcing scrolling inside the frame.
- 900px shows the profile card, tips, and composer comfortably without dominating the page.

## Test plan
- [ ] After merge + Pages deploy, reload `alejandrofuentepinero.github.io` (hard refresh to bust cache).
- [ ] Confirm the chat input + send button are visible without scrolling inside the iframe.
- [ ] Mobile: layout still doesn't break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)