### PR TITLE
Bump digital-twin iframe height to 1100px

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -27,7 +27,7 @@ These days I work at the intersection of AI engineering and data science, buildi
   <iframe
     src="https://alejandrofupi-digital-twin.hf.space"
     title="Digital twin chat"
-    style="width: 100%; height: 900px; border: 1px solid #e5e5e5; border-radius: 6px;"
+    style="width: 100%; height: 1100px; border: 1px solid #e5e5e5; border-radius: 6px;"
     loading="lazy"
     allow="clipboard-write"
   ></iframe>


### PR DESCRIPTION
## Summary
- 900px still cropped the chat composer because Gradio's message-history pane expands to fill available vertical space and pushes the input/send button below the iframe edge.
- 1100px should be enough headroom to seat the composer in view.

## Test plan
- [ ] After deploy, hard-refresh the home page; confirm the chat input + send button are visible without scrolling inside the iframe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)