### PR TITLE
Phase 5 follow-up: active-voice fixes on 404 and terms

### DIFF
--- a/_pages/404.md
+++ b/_pages/404.md
@@ -5,6 +5,6 @@ sitemap: false
 permalink: /404.html
 ---
 
-This page does not exist. The address may have changed when the site was rebuilt.
+This page does not exist. The address may have changed when I rebuilt the site.
 
 Try the [home page](/) or the [sitemap](/sitemap/), or [email me](mailto:alejandrofuentepinero@gmail.com) the broken link.

--- a/_pages/terms.md
+++ b/_pages/terms.md
@@ -12,10 +12,10 @@ The theme toggle stores your light or dark choice in your browser with localStor
 
 GitHub Pages hosts this site. GitHub may log requests to serve it. See the [GitHub privacy statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement).
 
-The digital twin chat on the [home page](/) runs on Hugging Face. Messages you send it are processed and logged on that service so the system can be monitored. Do not send personal information into the chat.
+The digital twin chat on the [home page](/) runs on Hugging Face. That service processes and logs the messages you send, so I can monitor the system. Do not send personal information into the chat.
 
 Some pages link to external sites. Their privacy practices are their own.
 
 ## Terms
 
-The content on this site is provided as is, without warranty. Published abstracts and citations remain with their journals and authors.
+Content on this site comes as is, without warranty. Published abstracts and citations remain with their journals and authors.


### PR DESCRIPTION
Three sentences on 404.md and terms.md were edited to active voice after their commit and missed PR #10. This lands the working-tree versions the Gate 5 metrics were computed on. No other changes.