### PR TITLE
Phase 5: teaching, the post, and the closing checker extension

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -233,3 +233,27 @@ Produced on branch `refurb/phase-5-talks`, 2026-08-07. Numbering continues from 
 ## Tooling
 
 108. **prose_check reads talks the way it reads publications.** `check_publication` became `check_front_matter`, shared by both collections with a `has_page` flag. All 12 talk files are checked on the excerpt (20-word ceiling, no questions); the 4 page files add the summary (Tier B, 100-word budget) and the rule that the body holds nothing but the record. The 8 rows-only files render as redirects, so their unrendered bodies are treated as records and only the excerpt is checked, which is why the em dashes in the NFFF and IBRC abstracts never reach a reader or the checker. A new check fires if a rows-only entry grows a summary that nothing would render. All 12 new checks fired on seeded violations before landing clean.
+
+# DECISIONS.md: Phase 5 judgment calls, teaching and posts pass
+
+Produced on branch `refurb/phase-5-teaching-posts`, 2026-08-07. Numbering continues from the talks pass. Working rule unchanged: only pressing decisions were surfaced; everything else follows best practice and is logged here. Settled before the pass started: the teaching collection stays `output: false` with its 2 stubs (DECISIONS 41), the student abstract is a third-party record routed like the paper and talk abstracts, the 2 named record repairs fall under the DECISIONS 69 rule, and the post keeps its content with the chapter list exempt.
+
+## Copy
+
+109. **The course list renders as a collapsed block, not an open list.** The list is a record and exempt from the 120-word teaching budget, but 11 entries under 6 year headings would dominate the page the way the 367-word migration did (FINDINGS 15). A "Course list" disclosure follows the page's own editorial service block and the /work/ certificates block: the visible prose states the shape (11 roles, 6 courses, 2019 to 2025) and the record sits complete at level 3. The nomination list stays open on its own page because that page exists for the record; the teaching section is one of 4 on /research/.
+
+110. **Record repairs, 6 words, under the DECISIONS 69 rule.** "Guess lecturer" became "Guest lecturer" (FINDINGS 15), 4 lowercase "demonstrator" role lines were capitalised to the majority form, and "Toolkit for the Field Biologist" gained the final period every sibling line carries. Course titles, years, degree levels and the lecture title are untouched, including the lowercase "Advanced statistics" (FINDINGS 18).
+
+111. **The mentoring entry opens with the student's finding and keeps every fact in prose.** Result first, then Olivia Bond, Johns Hopkins University, the School for International Training and the year, then the method. The project title sits verbatim in record markers and the abstract is byte-identical inside a collapsed "Project abstract" block. The framing deliberately does not reuse the IBRC 2025 talk excerpt's wording: related work, 2 surfaces, no copy (the DECISIONS 100 principle). The old "**Abstract**" label line was presentation, replaced by the disclosure label, per the DECISIONS 103 reading.
+
+112. **Entry titles: "Courses" and "Mentoring".** "Teaching: James Cook University" repeated the section heading above it and the venue line below it. Titles are the site's own labels, not records; venue and location render from front matter unchanged.
+
+113. **The post's opening 2 paragraphs are the publisher's text, marked as a record.** This settles the open question the pass carried: the wording matches CSIRO Publishing's description of the book, so it is third-party text under brief 6.4, never reworded. Both paragraphs moved byte-identical into record markers inside a collapsed "Publisher's description" block, and new owner prose opens the post with the result. The post title now names the book as published, The Action Plan for Australian Birds 2020, replacing the 2021 misname; the permalink is unchanged, so no URL moves and MIGRATIONS.md gains no line.
+
+114. **The post renders the chapter list from `_data/book_chapters.yml`**, executing the DECISIONS 52 single-source rule. The hand-typed list was verified identical to the data file on all 14 items before it was replaced with a Liquid loop, so the same record now renders on /research/ and the post from one source and cannot diverge. The counts in the post prose stay hand-written numerals: the no-literal-digit rule is scoped to the stats include, and the 2021 book cannot grow a 15th account.
+
+## Tooling
+
+115. **prose_check reads the teaching files directly and joins the /research/ budget to what the page serves.** The entries reach the page through Liquid (DECISIONS 41), so the checker reads them the way it reads `_data/apps.yml`: per-file Tier B checks with dash scans outside record regions, plus a 120-word section budget shared across the 2 files. Their words also join research.html's page total together with the 24 publication and talk excerpts its rows render, so the 700-word page budget now measures the rendered page: 694 of 700 words, which closes FINDINGS 15. Every check newly applied to these files fired on a seeded violation before landing clean (14 violations in the seeded run, committed in the gate evidence).
+
+116. **The post's budget is 120, not CONTENT_MAP's "keep 746".** The 746 was the whole old post, blurb and list included. Both are records now, so the budget applies to the owner's prose alone, at the level 2 standard every other page opener carries. The content the 746 described survives complete: blurb collapsed, list rendered from the data file.

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -34,8 +34,14 @@ Found while working, not fixed, per the working rules in REFURB_BRIEF.md section
 
 ## Phase 5, talks pass
 
-15. **The teaching section is 3 times its word budget.** CONTENT_MAP 8 budgets 120 words for teaching on /research/; the 2 entries render 367. They were migrated whole in Phase 4 and are the next pass's material, so nothing was touched here. The page's rendered prose total sits above the 700 budget mainly because of them. Seen in passing while checking the rendered page, for that pass to fix: the James Cook University entry records "Role: Guess lecturer" where it means guest lecturer.
+15. **The teaching section is 3 times its word budget.** CONTENT_MAP 8 budgets 120 words for teaching on /research/; the 2 entries render 367. They were migrated whole in Phase 4 and are the next pass's material, so nothing was touched here. The page's rendered prose total sits above the 700 budget mainly because of them. Seen in passing while checking the rendered page, for that pass to fix: the James Cook University entry records "Role: Guess lecturer" where it means guest lecturer. *Resolved in the teaching and posts pass: the section prose is 97 words against the 120 budget, the course list is a collapsed record, "Guest lecturer" is repaired, and the page budget check now passes on the rendered page at 694 of 700 (DECISIONS 109, 110, 115).*
 
 16. **Doubled spaces inside 3 talk locations**: "Mission Beach,  Australia", "Palm Cove,  Australia" and "Santa Cruz,  Chile". Locations are facts and were not touched, and HTML collapses the space so nothing renders wrong. Worth a single pass if the owner ever wants the source clean.
 
 17. **The 8 rows-only talk files keep full abstracts that nothing renders.** Their `redirect_to` output replaces the body (DECISIONS 39), so the text survives in the source as a record and never reaches a reader. That is deliberate, but it means those abstracts are outside every prose check. If a rows-only talk is ever promoted to a page, wrap its abstract in record markers and add a summary first, or the checker will fail the file.
+
+## Phase 5, teaching and posts pass
+
+18. **"Advanced statistics" is the one lowercase course title** against Title Case siblings in the course list. A course title is a record, so it stays as recorded; correcting it against the university's handbook name is an owner call.
+
+19. **Suspected slips inside the chapter citations**, now rendered from `_data/book_chapters.yml` on 2 surfaces: items 1 and 13 both read "pp. 744-746", but the Grey-headed Robin and Bower's Shrike-thrush accounts cannot share a page range. "Oreoscupus gutturalis" for the Fernwren is usually spelled Oreoscopus, and "Heteremyias cinereifrons" usually Heteromyias. Citation strings are never edited under the hard rule; correcting them against the published book is an owner call.

--- a/TERMINOLOGY.md
+++ b/TERMINOLOGY.md
@@ -80,6 +80,16 @@ their original wording and outrank this file.
 | Press and pulse | press for gradual trends, pulse for extreme events | chronic and acute | The thesis's own pairing, used in prose on the seminar page. |
 | The bat species | spectacled flying fox, then flying foxes | Spectacled Flying Fox in prose | Capitalised only inside verbatim records and the talk title. |
 
+## Teaching and the post (added in the teaching and posts pass)
+
+| Concept | Term | Not | Notes |
+|---|---|---|---|
+| The two teaching entries | Courses, Mentoring | Teaching: James Cook University | Entry titles under the /research/ Teaching heading. Venue and location render from front matter. |
+| The collapsed course record | Course list | Teaching history, Appointments | Mirrors the editorial service and certificates disclosures. |
+| The student abstract block | Project abstract | Original abstract as submitted | A student's project abstract is a third-party record under brief 6.4. The "as submitted" label belongs to the owner's talks. |
+| Mentoring in prose | I mentored | supervised, coached | Matches the entry title "Mentoring". |
+| The publisher blurb block | Publisher's description | About the book, Blurb | Third-party record, byte-identical, attributed by its label. |
+
 ## Acronym policy
 
 Expand every acronym on first use per page (section 6.2 rule 10). Exceptions,

--- a/_posts/2021-12-01-action-plan-australian-birds.md
+++ b/_posts/2021-12-01-action-plan-australian-birds.md
@@ -1,5 +1,5 @@
 ---
-title: 'The Action Plan for Australian Birds 2021'
+title: 'The Action Plan for Australian Birds 2020'
 date: 2021-12-01
 permalink: /posts/action-plan-australian-birds-2021/
 redirect_from:
@@ -9,23 +9,29 @@ tags:
   - Climate change
   - Threatened species
 ---
+
+I co-authored 14 species accounts in The Action Plan for Australian Birds 2020, with Stephen Williams and colleagues. The plan reviews the conservation status of every Australian bird and appears each decade. CSIRO Publishing released this edition in December 2021.
+
+The accounts cover upland rainforest birds of the Australian Wet Tropics, where warming pushes populations toward the mountain tops. The same monitoring evidence supported formal protection nominations for all 14 species, listed on the [nomination record](/research/threatened-species/).
+
+<details class="disclosure">
+  <summary><span class="label">Publisher's description</span></summary>
+  <div class="disclosure__body" markdown="1">
+
+<!-- record -->
+
 The Action Plan for Australian Birds 2020 is the most comprehensive review of the status of Australia's avifauna ever attempted. The latest in a series of action plans for Australian birds that have been produced every decade since 1992, it is also the largest. The accounts in this plan have been authored by more than 300 of the most knowledgeable bird experts in the country, and feature far more detail than any of the earlier plans. This volume also includes accounts of over 60 taxa that are no longer considered threatened, mainly thanks to sustained conservation action over many decades.
 This extensive book covers key themes that have emerged in the last decade, including the increasing impact of climate change as a threatening process, most obviously in Queensland's tropical rainforests where many birds are being pushed up the mountains. However, the effects are also indirect, as happened in the catastrophic fires of 2019/20. Many of the newly listed birds are subspecies confined to Kangaroo Island, where fire destroyed over half the population. But there are good news stories too, especially on islands where there have been spectacular successes with predator control. Such uplifting results demonstrate that when action plans are followed by action on the ground, threatened species can indeed be recovered and threats alleviated.
 
-Chapters contribution:
-======
+<!-- /record -->
 
-1.	Williams S.E., de la Fuente A., Freeman AND, Craig M, Frith DW, Frith CB, Garnett ST. (2021). Grey-headed Robin Heteremyias cinereifrons. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 744-746. CSIRO Publishing, Melbourne.
-2.	Williams S.E., de la Fuente A., Frith CB, Frith DW, Garnett ST. (2021). Victoria’s riflebird Lophorina victoriae. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 737-739. CSIRO Publishing, Melbourne.
-3.	Williams S.E., de la Fuente A., Garnett ST. (2021). Wet Tropics Eastern Whipbird Psophodes olivaceus lateralis. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 722-724. CSIRO Publishing, Melbourne.
-4.	Williams S.E., de la Fuente A., Harrington GN, Frith CB, Frith DW, Chaplin D, Freeman AND, Craig M, Garnett ST. (2021). Tooth-billed Bowerbird Scenopoeetes dentirostris. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 483-486. CSIRO Publishing, Melbourne.
-5.	Williams S.E., de la Fuente A., Frith CB, Frith DW, Chaplin D, Garnett ST. (2021). Wet Tropics Satin Bowerbird Ptilonorhynchus violaceus. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 489-491. CSIRO Publishing, Melbourne.
-6.	Williams S.E., de la Fuente A., Garnett ST. (2021). Little Treecreeper Cormobates leucophaea minor. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 495-497. CSIRO Publishing, Melbourne.
-7.	Williams S.E., de la Fuente A., Frith CB, Frith DW, Chaplin D, Garnett ST. (2021). Golden Bowerbird Prionodura newtoniana. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 486-488. CSIRO Publishing, Melbourne.
-8.	Williams S.E., de la Fuente A., Grant JDA, Garnett ST. (2021). Fernwren Oreoscupus gutturalis. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 644-646. CSIRO Publishing, Melbourne.
-9.	Williams S.E., de la Fuente A., Freeman AND, Garnett ST. (2021). Wet Tropics Brown Gerygone Gerygone mouki mouki. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 649-651. CSIRO Publishing, Melbourne.
-10.	Williams S.E., de la Fuente A., Garnett ST. (2021). Atherton Scrubwren Sericornis keri. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 672-674. CSIRO Publishing, Melbourne.
-11.	Williams S.E., de la Fuente A., Freeman AND, Craig M, Garnett ST. (2021). Wet Tropics Large-billed Scrubwren Sericornis magnirostra viridior. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 676-678. CSIRO Publishing, Melbourne.
-12.	Williams S.E., de la Fuente A., Garnett ST. (2021). Mountain Thornbill Acanthiza katherina. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 695-697. CSIRO Publishing, Melbourne.
-13.	Williams S.E., de la Fuente A., Freeman AND, Craig M, Garnett ST. (2021). Bower’s Shrike-thrush Colluricincla boweri. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 744-746. CSIRO Publishing, Melbourne.
-14.	Williams S.E., de la Fuente A., Freeman AND, Craig M, Garnett ST. (2021). Wet Tropics Australian King-Parrot Alisterus scapularis minor. In The Action Plan for Australian Birds 2020. (Eds ST Garnett and GB Baker) pp. 467-469. CSIRO Publishing, Melbourne.
+  </div>
+</details>
+
+## The 14 species accounts
+
+<ol>
+  {% for chapter in site.data.book_chapters %}
+  <li>{{ chapter.citation }}</li>
+  {% endfor %}
+</ol>

--- a/_teaching/james_cook_university.md
+++ b/_teaching/james_cook_university.md
@@ -1,5 +1,5 @@
 ---
-title: "Teaching: James Cook University"
+title: "Courses"
 collection: teaching
 type: "Undergraduate and Master's courses"
 permalink: /teaching/james_cook_university/
@@ -8,8 +8,13 @@ location: "Townsville, Australia"
 date: "2019-01-01"
 ---
 
+I held 11 teaching roles across 6 courses at James Cook University between 2019 and 2025. I tutored and demonstrated in undergraduate ecology, demonstrated in Master's statistics, helped develop a course, and gave a guest lecture on conservation under climate change.
 
-My teaching experience includes tutoring and lecturing on ecological courses and advanced statistics.
+<details class="disclosure">
+  <summary><span class="label">Course list</span></summary>
+  <div class="disclosure__body" markdown="1">
+
+<!-- record -->
 
 #### 2025
 - Climate Change and Biodiversity. 
@@ -19,31 +24,31 @@ My teaching experience includes tutoring and lecturing on ecological courses and
 #### 2023
 - Fundamentals of Ecology.
   - Course: Undergraduate.
-  - Role: demonstrator.
+  - Role: Demonstrator.
  
 #### 2022
 - Conservation Biology. 
   - Course: Master's degree. 
-  - Role: Guess lecturer. 
+  - Role: Guest lecturer. 
   - Title: "Targeted conservation actions under climate change".
 - Population and Community Ecology. 
   - Course: Undergraduate. 
   - Role: Tutor and field demonstrator.
 - Advanced statistics. 
   - Course: Master's degree. 
-  - Role: demonstrator and tutor.
+  - Role: Demonstrator and tutor.
 - Fundamentals of Ecology.
   - Course: Undergraduate.
-  - Role: demonstrator and course development.
+  - Role: Demonstrator and course development.
 
 #### 2021
 - Fundamentals of Ecology.
   - Course: Undergraduate.
-  - Role: demonstrator and course development.
+  - Role: Demonstrator and course development.
 - Population and Community Ecology. 
   - Course: Undergraduate. 
   - Role: Tutor and field demonstrator.
-- Toolkit for the Field Biologist
+- Toolkit for the Field Biologist.
   - Course: Undergraduate.
   - Role: Demonstrator and marking. 
 
@@ -56,3 +61,8 @@ My teaching experience includes tutoring and lecturing on ecological courses and
 - Climate Change and Biodiversity. 
   - Course: Undergraduate. 
   - Role: Demonstrator.
+
+<!-- /record -->
+
+  </div>
+</details>

--- a/_teaching/mentoring.md
+++ b/_teaching/mentoring.md
@@ -8,19 +8,18 @@ location: "Cairns, Australia"
 date: "2025-01-01"
 ---
 
+The worst heat stress responses in the spectacled flying fox come when high temperature and high solar exposure coincide. Olivia Bond, a Johns Hopkins University student with the School for International Training, showed this in the 2025 field project I mentored. She joined behavioural observations to microclimate measurements and modelled the responses with boosted regression trees.
 
-**Olivia Bond**
-
-2025
-
-*Johns Hopkins University*
-
-*School for International Training*  
+<!-- record -->
 **Project:** *Microclimate drivers of thermoregulatory behaviors in spectacled flying-foxes (Pteropus conspicillatus)*
+<!-- /record -->
 
----
+<details class="disclosure">
+  <summary><span class="label">Project abstract</span></summary>
+  <div class="disclosure__body" markdown="1">
 
-**Abstract**  
+<!-- record -->
+
 As climate change makes heat waves more frequent and intense, vulnerable species are pushed closer to their limits of thermal tolerance. The spectacled flying-fox (*Pteropus conspicillatus*) is an endangered megabat that plays a crucial role in pollination and seed dispersal for rainforest trees in northeast Australia. These bats are particularly vulnerable to extreme heat because they roost high in the canopy during the day.  
 
 Several studies have documented their thermoregulatory responses to high ambient temperatures, but temperature is only one factor influencing thermal stress, and the role of other microclimate drivers remains understudied.  
@@ -28,3 +27,8 @@ Several studies have documented their thermoregulatory responses to high ambient
 This project combined focal behavioral observations with microclimate measurements to identify the conditions that exacerbate heat stress. Behavioral responses were modeled using boosted regression trees, revealing that high temperatures alone did not always trigger active thermoregulation. The most extreme responses occurred when high temperatures coincided with high solar exposure, highlighting solar exposure as a critical but often overlooked driver of thermal stress.  
 
 These findings emphasize the need to consider the complexity of microclimate in predicting species’ vulnerability to extreme heat events.
+
+<!-- /record -->
+
+  </div>
+</details>

--- a/docs/phase-5-evidence/build-output-teaching-posts.txt
+++ b/docs/phase-5-evidence/build-output-teaching-posts.txt
@@ -1,0 +1,8 @@
+Configuration file: /Users/alejandrofp/Projects/portfolio/alejandrofuentepinero.github.io/_config.yml
+            Source: /Users/alejandrofp/Projects/portfolio/alejandrofuentepinero.github.io
+       Destination: /Users/alejandrofp/Projects/portfolio/alejandrofuentepinero.github.io/_site
+ Incremental build: disabled. Enable with --incremental
+      Generating... 
+       Jekyll Feed: Generating feed for posts
+                    done in 0.379 seconds.
+ Auto-regeneration: disabled. Use --watch to enable.

--- a/docs/phase-5-evidence/gate-5-teaching-posts.md
+++ b/docs/phase-5-evidence/gate-5-teaching-posts.md
@@ -1,0 +1,155 @@
+# Gate 5 evidence: the teaching and posts pass
+
+Branch `refurb/phase-5-teaching-posts`, 2026-08-07. Scope: the 2 files in
+`_teaching/`, the 1 file in `_posts/`, the prose_check extension to both
+collections, the TERMINOLOGY additions, and the DECISIONS (109 to 116) and
+FINDINGS (18 and 19) entries. No layout or include changed: the /research/
+teaching section and the post layout render the new content as they are.
+No URL moved, so MIGRATIONS.md gains no line. This PR closes Phase 5.
+
+## 1. Record integrity
+
+Verified programmatically against `refurb/main` before anything else
+(`record-check-teaching-posts.txt`).
+
+**The course list** carries exactly 6 word-level repairs under the
+DECISIONS 69 rule and no other change:
+
+```
+replace: old=['demonstrator.'] -> new=['Demonstrator.']
+replace: old=['Guess'] -> new=['Guest']
+replace: old=['demonstrator'] -> new=['Demonstrator']   (3 role lines)
+replace: old=['Biologist'] -> new=['Biologist.']
+facts-ok: all 6 course titles, the lecture title, both degree levels
+and all 6 years verbatim
+```
+
+**The student project abstract** (Olivia Bond, 2025) is byte-identical
+(1,275 bytes) inside record markers in a collapsed "Project abstract"
+block, per the third-party-record rule in brief 6.4. The project title
+sits verbatim in its own record markers, and the student's name, year and
+both institutions appear verbatim in the framing prose.
+
+**The publisher's description** is byte-identical (1,353 bytes) inside
+record markers in a collapsed block. The pass confirmed the open question
+it carried: the post's opening 2 paragraphs match CSIRO Publishing's
+description of the book, so they are third-party text, marked as a record
+and never reworded (DECISIONS 113).
+
+**The chapter list** in the old post was verified identical to
+`_data/book_chapters.yml` on all 14 items, then replaced with a Liquid
+loop over the data file, so the record that renders on /research/ and on
+the post now has one source (DECISIONS 114). The built post renders all
+14 citations.
+
+## 2. Metrics
+
+Output of `python3 scripts/prose_check.py --metrics` committed as
+`prose-check-output-teaching-posts.txt`. All 3 files are Tier B. The
+teaching budget of 120 words is shared across both entries; records
+(course list, project abstract, publisher's description, chapter list)
+are exempt and collapsed.
+
+| file | words / budget | sentences | mean | longest | em+en dashes | banned hits |
+|---|---|---|---|---|---|---|
+| _teaching/james_cook_university.md | 41 of the shared 120 | 2 | 20.5 | 25 | 0 | 0 |
+| _teaching/mentoring.md | 56 of the shared 120 | 3 | 18.7 | 22 | 0 | 0 |
+| teaching combined | 97/120 | 5 | | | 0 | 0 |
+| _posts/2021-12-01-action-plan-australian-birds.md | 80/120 | 5 | 15.2 | 19 | 0 | 0 |
+
+The teaching section drops from 367 rendered words (FINDINGS 15) to 97
+words of prose. The /research/ page budget check now measures the
+rendered page (own blocks, both teaching entries, and the 24 publication
+and talk excerpts its rows render) and passes at **694/700**. Em dash
+count 0 and en dash count 0 outside record regions in every touched
+file, front matter included. Banned word hits 0, unexpanded acronyms 0,
+no paragraph over 4 sentences, no sentence over the Tier B 25.
+
+## 3. Side-by-side
+
+**_teaching/james_cook_university.md.** Before: title "Teaching: James
+Cook University", one intro line ("My teaching experience includes
+tutoring and lecturing on ecological courses and advanced statistics."),
+then the full 45-line course list open on the page. After: title
+"Courses" (the old title repeated the section heading and the venue
+line, DECISIONS 112), 2 sentences of framing ("I held 11 teaching roles
+across 6 courses at James Cook University between 2019 and 2025. I
+tutored and demonstrated in undergraduate ecology, demonstrated in
+Master's statistics, helped develop a course, and gave a guest lecture
+on conservation under climate change."), then the repaired course list
+as a record inside a collapsed "Course list" block (DECISIONS 109, 110).
+
+**_teaching/mentoring.md.** Before: name, year and institution lines,
+then the project abstract printed in full under a bold "Abstract" label.
+After: the entry opens with the student's finding ("The worst heat
+stress responses in the spectacled flying fox come when high temperature
+and high solar exposure coincide."), names Olivia Bond, Johns Hopkins
+University, the School for International Training and the method, then
+the project title and the byte-identical abstract sit as records, the
+abstract collapsed (DECISIONS 111). The framing does not reuse the IBRC
+2025 talk excerpt's wording: related work, 2 surfaces, no copy.
+
+**_posts/2021-12-01-action-plan-australian-birds.md.** Before: title
+"The Action Plan for Australian Birds 2021" (the book is the 2020 plan),
+the publisher's 2 paragraphs presented as the owner's prose, a broken
+"Chapters contribution:" setext heading, and the hand-typed 14-item
+list. After: the corrected title, 76 words of owner prose opening with
+the result ("I co-authored 14 species accounts...") and closing on the
+nomination record cross-link, the publisher's description collapsed as
+an attributed record, and the list rendered from the data file under
+"The 14 species accounts". The post's meta description now serves the
+owner's first paragraph instead of the blurb.
+
+## 4. Audience check
+
+**The teaching section on /research/.** Recruiter: university teaching at
+a glance, 11 roles to Master's level, and a mentored student project
+that reached a result. Peer: statistics demonstration, course
+development and a guest lecture topic in one paragraph, with boosted
+regression trees and the microclimate finding in the mentoring entry.
+Academic: the complete course history with years, levels and the
+verbatim lecture title one click down, and the student's abstract
+preserved untouched.
+
+**The post.** Recruiter: 14 co-authored accounts in the decade's
+national bird review, stated in the first sentence. Peer: monitoring
+evidence flowing into formal protection nominations, with the nomination
+record linked. Academic: the correct book title, the publisher's
+context, and all 14 citations rendered in full.
+
+## 5. Checker and build
+
+`prose_check` runs green over 53 files plus the stats include
+(`prose-check-output-teaching-posts.txt`). The teaching entries reach
+the page through Liquid, so the checker reads the 2 files directly, the
+way it reads `_data/apps.yml`: per-file Tier B checks, dash scans
+outside record regions, the shared 120-word section budget, and the join
+of teaching words and row excerpts into the /research/ page budget
+(DECISIONS 115). Every check newly applied to these files fired on a
+seeded violation before landing clean; the 14-violation run is
+`seeded-violations-teaching-posts.txt`. The build is warning-free
+(`build-output-teaching-posts.txt`). CI runs the checker via the
+existing workflow on this branch's pushes and PR.
+
+**Coverage is now complete.** With this pass the checker covers every
+markdown file the site serves as readable content: 10 pages, 16
+projects, 12 publications, 12 talks, the post and the 2 teaching
+entries, 53 files. What remains outside it remains by design: the
+redirect stubs in `_pages/redirects/` render no prose, the 8 rows-only
+talk bodies render as redirects (FINDINGS 17), the styleguide is
+internal, and the project documents are excluded from the build. Phase
+7's requirement that `prose_check` run clean across every markdown file
+becomes true at this gate.
+
+## 6. Phase 5 closes here
+
+All 7 collections in the brief's Phase 5 list are done: `_pages`,
+`_projects`, the apps copy, `_publications`, `_talks`, `_teaching` and
+`_posts`. Remaining for Phase 6 (performance, SEO, accessibility, per
+brief section 7): webp with fallback and explicit dimensions, the real
+1200x630 `og:image`, JSON-LD (Person, ScholarlyArticle, CreativeWork,
+SoftwareApplication), rewritten titles and meta descriptions,
+accessibility (contrast, focus, heading order, alt text, skip link, the
+iframe title), `robots.txt` and a clean `sitemap.xml`, the Lighthouse
+and bundle targets, and the orphaned-asset sweep (FINDINGS 3). Open
+owner calls carried in FINDINGS: 6, 8, 9, 13, 14, 18, 19.

--- a/docs/phase-5-evidence/prose-check-output-teaching-posts.txt
+++ b/docs/phase-5-evidence/prose-check-output-teaching-posts.txt
@@ -1,0 +1,56 @@
+file                                                tier  words       lead     sents  mean   longest  dashes  banned
+_teaching/james_cook_university.md                  B     41/-        -        2      20.5   25       0       0
+_teaching/mentoring.md                              B     56/-        -        3      18.7   22       0       0
+_pages/home.html                                    B     174/450     -        14     10.9   21       0       0
+_pages/work.md                                      B     276/420     -        13     16.5   23       0       0
+_pages/projects.html                                B     34/440      -        3      11.0   13       0       0
+_pages/apps.html                                    A     198/200     -        16     12.0   20       0       0
+_pages/research.html                                B     694/700     -        6      15.3   24       0       0
+_pages/contact.md                                   B     38/60       -        3      10.7   12       0       0
+_pages/404.md                                       A     28/30       -        3      9.3    13       0       0
+_pages/sitemap.md                                   A     74/120      -        2      9.0    11       0       0
+_pages/terms.md                                     A     129/150     -        15     8.5    15       0       0
+_pages/threatened_species.md                        B     101/150     -        7      14.4   21       0       0
+_projects/7ph-graph.md                              A     975/-       95/120   72     12.1   20       0       0
+_projects/ai-jie.md                                 A     615/-       93/120   46     12.1   19       0       0
+_projects/digital-twin.md                           A     627/-       97/120   46     12.4   19       0       0
+_projects/job-intelligence-engine.md                A     545/-       89/120   42     12.0   19       0       0
+_projects/llm-engineering-lab.md                    A     830/-       85/120   66     11.2   20       0       0
+_projects/mlb-analytics-sql.md                      A     185/-       75/120   13     12.2   20       0       0
+_projects/python-labs.md                            A     301/-       57/120   20     12.4   20       0       0
+_projects/bird-elevational-migration.md             A     389/-       93/120   25     14.6   20       0       0
+_projects/dynamic-community-reshuffling.md          A     383/-       92/120   25     14.1   19       0       0
+_projects/ecosystem-pathway-cascades.md             A     385/-       81/120   24     14.5   20       0       0
+_projects/forecasting-popviability-ringtails.md     A     414/-       94/120   29     13.0   18       0       0
+_projects/forest-gap-abundance-gradients.md         A     378/-       83/120   26     13.0   20       0       0
+_projects/heightened-protection-bird-trends.md      A     405/-       93/120   28     13.2   19       0       0
+_projects/physiological-stress-climate-populations.mdA     453/-       83/120   32     13.0   20       0       0
+_projects/predicting-abundance-from-niche-theory.md A     426/-       80/120   31     12.5   20       0       0
+_projects/spatiotemporal-bird-climate-impacts.md    A     427/-       85/120   29     13.3   20       0       0
+_publications/delafuente_pacheco_2017_bosque.md     B     105/120     23/25    9      14.2   22       0       0
+_publications/gallardo_et_al_2018.md                B     89/120      23/25    8      14.0   23       0       0
+_publications/delafuente_et_al_2021_ecography.md    B     95/120      25/25    8      15.0   20       0       0
+_publications/Williams_delafuente_2021.md           B     118/120     23/25    9      15.7   23       0       0
+_publications/iriarte_et_al_2021.md                 B     82/120      16/25    6      16.3   23       0       0
+_publications/delafuente_et_al_2022_ddi_reshuffling.mdB     106/120     25/25    9      14.6   19       0       0
+_publications/delafuente_williams_2022_possums_ddi.mdB     113/120     23/25    10     13.6   20       0       0
+_publications/delafuente_et_al_2023_GCB.md          B     118/120     24/25    9      15.8   24       0       0
+_publications/herbivory_awt_2024_oecologia.md       B     104/120     25/25    8      16.1   24       0       0
+_publications/delafuente_2025_GCB.md                B     95/120      21/25    8      14.5   21       0       0
+_publications/siri_et_al_2025.md                    B     111/120     23/25    9      14.9   21       0       0
+_publications/delafuente_2026_NCC.md                B     70/120      20/25    6      15.0   24       0       0
+_talks/zenq_2023.md                                 B     93/100      18/20    9      12.3   18       0       0
+_talks/esa_scbo_2022.md                             B     97/100      18/20    8      14.4   18       0       0
+_talks/PhD_completion_seminar.md                    B     97/100      16/20    9      12.6   24       0       0
+_talks/IBRC_2025.md                                 B     94/100      17/20    8      13.9   19       0       0
+_talks/cbcs_brisbane_2023.md                        B     0/100       17/20    1      17.0   17       0       0
+_talks/chilean_congress_ornithology_2017.md         B     0/100       17/20    1      17.0   17       0       0
+_talks/coder_nmix.md                                B     0/100       17/20    1      17.0   17       0       0
+_talks/NFFF_2025.md                                 B     0/100       18/20    1      18.0   18       0       0
+_talks/tess_2021.md                                 B     0/100       15/20    1      15.0   15       0       0
+_talks/tess_2023.md                                 B     0/100       19/20    1      19.0   19       0       0
+_talks/wtma_workshop.md                             B     0/100       16/20    1      16.0   16       0       0
+_talks/zenq_2022.md                                 B     0/100       18/20    1      18.0   18       0       0
+_posts/2021-12-01-action-plan-australian-birds.md   B     80/120      -        5      15.2   19       0       0
+
+prose_check: clean (53 files and the stats include)

--- a/docs/phase-5-evidence/record-check-teaching-posts.txt
+++ b/docs/phase-5-evidence/record-check-teaching-posts.txt
@@ -1,0 +1,24 @@
+Record integrity check, teaching and posts pass
+Old = refurb/main, new = working tree
+
+1. _teaching/james_cook_university.md course list
+   replace: old=['demonstrator.'] -> new=['Demonstrator.']
+   replace: old=['Guess'] -> new=['Guest']
+   replace: old=['demonstrator'] -> new=['Demonstrator']
+   replace: old=['demonstrator'] -> new=['Demonstrator']
+   replace: old=['demonstrator'] -> new=['Demonstrator']
+   replace: old=['Biologist'] -> new=['Biologist.']
+   6 word-level differences, all listed above; every other word identical
+   facts-ok: all 6 course titles, the lecture title, both degree levels and all 6 years verbatim
+
+2. _teaching/mentoring.md project abstract
+   byte-identical: True (1275 bytes)
+   project title verbatim in record markers: True
+   facts-ok: student name, year and both institutions verbatim
+
+3. _posts/2021-12-01-action-plan-australian-birds.md
+   publisher's description byte-identical: True (1353 bytes)
+   old hand-typed list vs _data/book_chapters.yml: 14/14 items identical
+   the post now renders the list from the data file, so one source serves both surfaces
+   title: 'The Action Plan for Australian Birds 2021' -> 'The Action Plan for Australian Birds 2020'
+   permalink and redirect_from unchanged: no URL moves, no MIGRATIONS.md entry needed

--- a/docs/phase-5-evidence/seeded-violations-teaching-posts.txt
+++ b/docs/phase-5-evidence/seeded-violations-teaching-posts.txt
@@ -1,0 +1,15 @@
+prose_check: 14 violation(s)
+  _pages/research.html: page at 754 words, over its budget of 700
+  _publications/delafuente_et_al_2021_ecography.md: excerpt of 30 words (max 25)
+  _posts/2021-12-01-action-plan-australian-birds.md: 1 em dash(es) outside record regions
+  _posts/2021-12-01-action-plan-australian-birds.md: banned word or construction "seamless" in: "The accounts cover upland rainforest birds of the Australian Wet Tropi"
+  _posts/2021-12-01-action-plan-australian-birds.md: sentence of 44 words (tier B max 25): "More seeded filler follows to carry the post past its level 2 budget o"
+  _posts/2021-12-01-action-plan-australian-birds.md: page at 132 words, over its budget of 120
+  _teaching/james_cook_university.md: 1 em dash(es) outside record regions
+  _teaching/james_cook_university.md: sentence of 30 words (tier B max 25): "I tutored and demonstrated in undergraduate ecology, demonstrated in M"
+  _teaching/james_cook_university.md: sentence of 26 words (tier B max 25): "Seeded filler words now push the shared teaching section well past its"
+  _teaching/mentoring.md: 1 en dash(es) outside record regions
+  _teaching/mentoring.md: banned word or construction "robust" in: "The worst heat stress responses in the spectacled flying fox come when"
+  _teaching/mentoring.md: sentence of 39 words (tier B max 25): "She joined behavioural observations to microclimate measurements in 20"
+  _teaching/mentoring.md: unknown acronym "XYZQ": expand it, add an expansion to ACRONYM_EXPANSIONS, or allowlist it per TERMINOLOGY.md
+  _teaching: 152 words of section prose across both entries, over the shared budget of 120

--- a/scripts/prose_check.py
+++ b/scripts/prose_check.py
@@ -16,10 +16,14 @@ Fails on:
  10. Any talk excerpt over 20 words or asking a question, any talk
      summary over 100 words, and any prose outside the record markers on
      a talk that has its own page.
+ 11. Any teaching-entry prose failing the Tier B checks, any dash
+     outside a teaching file's record regions, and the 2 entries'
+     combined prose over the shared teaching section budget.
 
-Scope: the files in FILES below plus the stats include. Later Phase 5
-passes extend FILES collection by collection. The styleguide (internal,
-exempt) and the redirect stubs (no prose) are deliberately absent.
+Scope: the files in FILES and TEACHING_FILES below plus the stats
+include. The styleguide (internal, exempt) and the redirect stubs (no
+prose) are deliberately absent, and the 8 rows-only talk bodies render
+as redirects, so nothing a reader can see is unchecked.
 
 Publication files (_publications/) render their prose from front matter:
 the excerpt is the index finding (25-word ceiling, no questions) and the
@@ -55,6 +59,21 @@ label spans, filter buttons and Liquid output are presentation tokens,
 not prose, and are removed before checking. Words inside Liquid include
 parameters (the twin frame context line) are not visible to this script;
 the Gate evidence counts them by hand.
+
+Teaching files (_teaching/) render inline on /research/ through Liquid
+(DECISIONS 41), so the page-level check on research.html never sees
+them: they are read directly, the way _data/apps.yml is. The course
+list and the student project abstract are records inside collapsed
+blocks; the visible framing prose is Tier B. The 2 entries share the
+CONTENT_MAP teaching budget of 120 words, and their words also join the
+/research/ page budget, together with the publication and talk excerpts
+its rows render, so the 700-word page budget measures what the page
+actually serves.
+
+The post (_posts/) is checked like a page: Tier B, with the level 2
+budget of 120 words on the owner's prose. The publisher's description
+sits inside record markers and the chapter list renders from
+_data/book_chapters.yml through Liquid, so neither counts.
 
 The /apps/ entries (pitch, demonstrates, note) live in _data/apps.yml,
 which Liquid renders into the page, so the page file alone never shows
@@ -133,7 +152,19 @@ FILES = {
     "_talks/tess_2023.md": ("B", 100),
     "_talks/wtma_workshop.md": ("B", 100),
     "_talks/zenq_2022.md": ("B", 100),
+    # The post: Tier B, level 2 budget on the owner's prose. Records
+    # (the publisher's description, the chapter list) are exempt.
+    "_posts/2021-12-01-action-plan-australian-birds.md": ("B", 120),
 }
+
+# Checked by check_teaching: read directly because the entries render
+# inline on /research/ through Liquid (DECISIONS 41). The budget is the
+# CONTENT_MAP section total, shared across both files.
+TEACHING_FILES = [
+    "_teaching/james_cook_university.md",
+    "_teaching/mentoring.md",
+]
+TEACHING_BUDGET = 120
 
 STATS_INCLUDE = "_includes/stats-band.html"
 APPS_DATA = "_data/apps.yml"
@@ -300,6 +331,52 @@ def apps_data_strings(fails):
     return texts
 
 
+def check_teaching(report):
+    """The 2 teaching entries, read directly (they render inline on
+    /research/ through Liquid, so check_file never sees them). Per-file
+    Tier B checks plus the shared section budget. Returns the combined
+    word count, which joins the /research/ page budget."""
+    total_words = 0
+    failures = []
+    for rel_path in TEACHING_FILES:
+        raw = (ROOT / rel_path).read_text(encoding="utf-8")
+        fails = []
+        stripped = strip_records(raw)
+        for name, char in (("em dash", EM_DASH), ("en dash", EN_DASH)):
+            count = stripped.count(char)
+            if count:
+                fails.append(f"{count} {name}(es) outside record regions")
+        blocks = extract_blocks(raw)
+        all_sentences = run_prose_checks(blocks, "B", fails)
+        words = sum(word_count(b) for b in blocks)
+        total_words += words
+        file_report(report, rel_path, "B", words, None, None,
+                    PROJECT_LEAD_BUDGET, all_sentences, fails)
+        failures.extend(f"{rel_path}: {fail}" for fail in fails)
+    if total_words > TEACHING_BUDGET:
+        failures.append(
+            f"_teaching: {total_words} words of section prose across both "
+            f"entries, over the shared budget of {TEACHING_BUDGET}"
+        )
+    return total_words, failures
+
+
+def rendered_excerpt_words():
+    """Words the /research/ rows render from publication and talk front
+    matter. Each excerpt is already checked in its own file; here they
+    count toward the page budget of the page that renders them."""
+    total = 0
+    for rel_path in FILES:
+        if not rel_path.startswith(("_publications/", "_talks/")):
+            continue
+        raw = (ROOT / rel_path).read_text(encoding="utf-8")
+        front = FRONT_MATTER_RE.match(raw).group(0)
+        excerpt_match = EXCERPT_RE.search(front)
+        if excerpt_match:
+            total += word_count(clean_prose(excerpt_match.group(1)))
+    return total
+
+
 def run_prose_checks(blocks, tier, fails):
     """The checks every prose block gets: banned words, sentence and
     paragraph limits, acronym expansion. Returns the sentence list."""
@@ -364,7 +441,7 @@ def file_report(report, rel_path, tier, words, budget, lead, lead_budget,
     }
 
 
-def check_file(rel_path, tier, budget, report):
+def check_file(rel_path, tier, budget, report, extra_words=0):
     path = ROOT / rel_path
     raw = path.read_text(encoding="utf-8")
     fails = []
@@ -383,7 +460,7 @@ def check_file(rel_path, tier, budget, report):
 
     all_sentences = run_prose_checks(blocks, tier, fails)
 
-    words = sum(word_count(b) for b in blocks)
+    words = sum(word_count(b) for b in blocks) + extra_words
     if budget is not None and words > budget:
         fails.append(f"page at {words} words, over its budget of {budget}")
 
@@ -511,6 +588,9 @@ def main():
     report = {}
     failures = []
 
+    teaching_words, teaching_failures = check_teaching(report)
+    research_extra = teaching_words + rendered_excerpt_words()
+
     for rel_path, (tier, budget) in FILES.items():
         if rel_path.startswith("_publications/"):
             fails = check_front_matter(rel_path, tier, budget,
@@ -523,9 +603,12 @@ def main():
                                        TALK_EXCERPT_BUDGET, report,
                                        has_page=not REDIRECT_TO_RE.search(front))
         else:
-            fails = check_file(rel_path, tier, budget, report)
+            extra = research_extra if rel_path == "_pages/research.html" else 0
+            fails = check_file(rel_path, tier, budget, report,
+                               extra_words=extra)
         for fail in fails:
             failures.append(f"{rel_path}: {fail}")
+    failures.extend(teaching_failures)
     failures.extend(check_stats_include())
 
     if show_metrics:
@@ -552,7 +635,10 @@ def main():
         for failure in failures:
             print(f"  {failure}")
         return 1
-    print(f"prose_check: clean ({len(FILES)} files and the stats include)")
+    print(
+        f"prose_check: clean ({len(FILES) + len(TEACHING_FILES)} files "
+        "and the stats include)"
+    )
     return 0
 
 


### PR DESCRIPTION
Closes Phase 5: `_teaching` and `_posts` were the last 2 collections in the phase. Full evidence in `docs/phase-5-evidence/gate-5-teaching-posts.md`.

## What changed

- **Courses** (was "Teaching: James Cook University"): 2 sentences of framing prose, then the course list as a record inside a collapsed "Course list" block. 6 word-level repairs under the DECISIONS 69 rule ("Guess lecturer" to "Guest lecturer", 4 "demonstrator" capitalisations, 1 missing period), everything else verbatim (DECISIONS 109, 110, 112).
- **Mentoring**: opens with the student's finding, keeps Olivia Bond's name, year and institutions in prose, and routes her project abstract byte-identical into record markers inside a collapsed "Project abstract" block, per brief 6.4 (DECISIONS 111).
- **The post**: the open question resolved as suspected. The opening 2 paragraphs match CSIRO Publishing's description of the book, so they are third-party text: collapsed as an attributed "Publisher's description" record, byte-identical. New owner prose (76 words) opens with the result. The chapter list now renders from `_data/book_chapters.yml`, one source for both surfaces (DECISIONS 113, 114). The title now names the book as published (2020, was 2021); the permalink is unchanged, so no URL moves.
- **prose_check** reads the 2 teaching files directly (they reach `/research/` through Liquid), enforces the shared 120-word teaching budget, and joins teaching words plus the 24 row excerpts into the `/research/` page budget, which now measures the rendered page: 694/700. The post joins FILES at Tier B, 120 (DECISIONS 115, 116).

## Gate 5

- Records byte-checked against `refurb/main`: the 6 course-list repairs and nothing else, abstract 1,275 bytes identical, blurb 1,353 bytes identical, chapter list 14/14 vs the data file (`record-check-teaching-posts.txt`).
- Metrics: teaching 97/120 (was 367 rendered, FINDINGS 15 resolved), post 80/120, dashes 0 and banned words 0 outside records everywhere.
- Every check newly applied to these files fired on a seeded violation before landing clean (14-violation run committed).
- `prose_check` clean over 53 files plus the stats include; warning-free build; CI green on the branch.
- **The checker now covers every markdown file the site serves as readable content.** The Phase 7 requirement that prose_check run clean across every markdown file becomes true at this gate.

## What remains for Phase 6

Performance, SEO and accessibility per brief section 7: webp with fallback, the real og:image, JSON-LD, titles and meta descriptions, contrast, focus and heading-order checks, robots.txt and sitemap.xml, the Lighthouse and bundle targets, and the orphaned-asset sweep (FINDINGS 3). Open owner calls in FINDINGS: 6, 8, 9, 13, 14, 18, 19.